### PR TITLE
root pathのroutingをpublic/index.htmlに設定した

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -31,6 +31,10 @@ skip_files:
 - ^node_modules/(.*/)?
 
 handlers:
+- url: /
+  mime_type: text/html
+  static_files: public/index.html
+  upload: public/index.html
 - url: /(.*\.html)
   mime_type: text/html
   static_files: public/\1

--- a/main.go
+++ b/main.go
@@ -1,9 +1,1 @@
 package main
-
-import (
-  "net/http"
-)
-
-func init() {
-  http.Handle("/", http.FileServer(http.Dir("./public")))
-}


### PR DESCRIPTION
app.yamlに以下のように書くと、go appまでrequestは来ず、static serverからResponseが返されるので、go側のfile配信処理を削除している。

```
- url: /(.*\.html)
  mime_type: text/html
  static_files: public/\1
  upload: public/(.*\.html)
```

因みに指定したpathをdirに割り振ることもできる。
以下のように書くと、 `/js/hoge.js` のrequestは、js dirの中のhoge.jsを返すようになる。

```
- url: /js
  static_dir: js
```

#1 